### PR TITLE
35 clean install gives npm err notarget no matching version found for docsify cli447

### DIFF
--- a/change.sh
+++ b/change.sh
@@ -1,11 +1,25 @@
 #!/bin/sh
 set -e
-goal="Create favicon.ico from logo.png"
+goal="Fix npm ERR! notarget for docsify-cli@^4.4.7"
 echo "Plan:"
-echo "1. Use convert utility to convert logo.png to favicon.ico"
-echo "2. Move the converted favicon.ico to the appropriate location"
+echo "1. Find the package.json file"
+echo "2. Check for docsify-cli version and edit it to latest available version"
+echo "3. Save the file and commit the changes"
 
-# convert logo.png to favicon.ico
-convert ./docs/assets/logo.png -resize 32x32 ./src/frontend/assets/favicon.ico
+# Navigate to root directory
+cd ./ 
+
+# Use node to edit the package.json to set the docsify-cli version to the latest available version
+node -e "
+let package = require('./package.json');
+package.dependencies['docsify-cli'] = '^4.4.4';
+require('fs').writeFileSync('./package.json', JSON.stringify(package, null, 2));
+"
+
+# Add the change to git
+git add package.json
+
+# Commit the change
+git commit -m "Fixing npm ERR! notarget for docsify-cli@^4.4.7, changed to version ^4.4.4"
 
 echo "\033[32mDone: $goal\033[0m\n"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "vite": "^4.3.9",
     "vite-plugin-solid": "^2.7.0",
     "ws": "^8.13.0",
-    "docsify-cli": "^4.4.7"
+    "docsify-cli": "^4.4.4"
   },
   "directories": {
     "doc": "docs"

--- a/prompt.md
+++ b/prompt.md
@@ -23,25 +23,41 @@
 
 # Task
 
-Implement the following feature!
+Fix the following issue!
 
-- Create a plan!
-- Create new files when needed!
+clean install gives: npm ERR! notarget No matching version found for docsify-cli@^4.4.7. #35
+pbharrin opened this issue 3 hours ago · 3 comments
+Comments
+pbharrin commented 3 hours ago
+A clean install gives me the following error:
+npm ERR! notarget No matching version found for docsify-cli@^4.4.7.
 
-Requirements:
+Running npm view docsify-cli versions
+returns
+[ &#39;0.1.0&#39;, &#39;0.2.1&#39;,  &#39;0.2.2&#39;,  &#39;1.0.0&#39;,  &#39;1.1.0&#39;, &#39;1.1.1&#39;, &#39;1.2.0&#39;,  &#39;1.2.1&#39;,  &#39;1.3.0&#39;,  &#39;1.4.0&#39;, &#39;1.5.0&#39;, &#39;1.5.1&#39;,  &#39;2.0.0&#39;,  &#39;2.1.0&#39;,  &#39;3.0.0&#39;, &#39;3.0.1&#39;, &#39;3.0.2&#39;,  &#39;3.1.0&#39;,  &#39;3.1.1&#39;,  &#39;3.2.0&#39;, &#39;3.2.1&#39;, &#39;3.2.2&#39;,  &#39;3.2.3&#39;,  &#39;3.2.4&#39;,  &#39;3.2.5&#39;, &#39;3.3.0&#39;, &#39;3.3.1&#39;,  &#39;3.3.2&#39;,  &#39;4.0.0&#39;,  &#39;4.0.1&#39;, &#39;4.0.2&#39;, &#39;4.1.0&#39;,  &#39;4.1.1&#39;,  &#39;4.1.2&#39;,  &#39;4.1.3&#39;, &#39;4.1.4&#39;, &#39;4.1.5&#39;,  &#39;4.1.6&#39;,  &#39;4.1.7&#39;,  &#39;4.1.8&#39;, &#39;4.1.9&#39;, &#39;4.1.10&#39;, &#39;4.1.11&#39;, &#39;4.1.12&#39;, &#39;4.2.0&#39;, &#39;4.2.1&#39;, &#39;4.3.0&#39;,  &#39;4.4.0&#39;,  &#39;4.4.1&#39;,  &#39;4.4.2&#39;, &#39;4.4.3&#39;, &#39;4.4.4&#39; ]
 
-Create src/frontend/assets/favicon.ico
-from docs/assets/logo.png
-convert is installed
+No version 4.4.7 has been published.
 
+@pbharrin
+Tip
+Author
+pbharrin commented 3 hours ago
+I also looked into the source of docsify-cli and could not find a 4.4.7.
 
+@tisztamo
+Tip
+Owner
+tisztamo commented 3 hours ago
+Uh, it was added today, I will check it soon but currently on mobile. Try to go back a few commits please!
 
-## Project Specifics
+@tisztamo
+Tip
+Owner
+tisztamo commented 3 hours ago
+Found the cause here:
+https://chat.openai.com/share/937d8682-300c-4e1f-84e5-607425cc4b21
 
-- Every js file should *only export a single function*!
-- Use *ES6 imports*!
-- Prefer *async/await* over promises!
-- The frontend uses *Solidjs*, edit .jsx file accordingly
+I asked gpt both to install docsify-cli and also to edit package.json by heredocing the full file, in the same script. So it guessed the version in order to not loose the newly installed dep.
 
 
 # Output Format

--- a/prompt.yaml
+++ b/prompt.yaml
@@ -1,8 +1,38 @@
-task: prompt/task/feature/implement.md
+task: prompt/task/bug/fix.md
 attention:
   - ./
 requirements: |
-  Create src/frontend/assets/favicon.ico
-  from docs/assets/logo.png
-  convert is installed
+  clean install gives: npm ERR! notarget No matching version found for docsify-cli@^4.4.7. #35
+  pbharrin opened this issue 3 hours ago · 3 comments
+  Comments
+  pbharrin commented 3 hours ago
+  A clean install gives me the following error:
+  npm ERR! notarget No matching version found for docsify-cli@^4.4.7.
+
+  Running npm view docsify-cli versions
+  returns
+  [ '0.1.0', '0.2.1',  '0.2.2',  '1.0.0',  '1.1.0', '1.1.1', '1.2.0',  '1.2.1',  '1.3.0',  '1.4.0', '1.5.0', '1.5.1',  '2.0.0',  '2.1.0',  '3.0.0', '3.0.1', '3.0.2',  '3.1.0',  '3.1.1',  '3.2.0', '3.2.1', '3.2.2',  '3.2.3',  '3.2.4',  '3.2.5', '3.3.0', '3.3.1',  '3.3.2',  '4.0.0',  '4.0.1', '4.0.2', '4.1.0',  '4.1.1',  '4.1.2',  '4.1.3', '4.1.4', '4.1.5',  '4.1.6',  '4.1.7',  '4.1.8', '4.1.9', '4.1.10', '4.1.11', '4.1.12', '4.2.0', '4.2.1', '4.3.0',  '4.4.0',  '4.4.1',  '4.4.2', '4.4.3', '4.4.4' ]
+
+  No version 4.4.7 has been published.
+
+  @pbharrin
+  Tip
+  Author
+  pbharrin commented 3 hours ago
+  I also looked into the source of docsify-cli and could not find a 4.4.7.
+
+  @tisztamo
+  Tip
+  Owner
+  tisztamo commented 3 hours ago
+  Uh, it was added today, I will check it soon but currently on mobile. Try to go back a few commits please!
+
+  @tisztamo
+  Tip
+  Owner
+  tisztamo commented 3 hours ago
+  Found the cause here:
+  https://chat.openai.com/share/937d8682-300c-4e1f-84e5-607425cc4b21
+
+  I asked gpt both to install docsify-cli and also to edit package.json by heredocing the full file, in the same script. So it guessed the version in order to not loose the newly installed dep.
 os: OSX


### PR DESCRIPTION
Copy-pasted the issue report and the conversation to prompt.yaml and voila: 

https://chat.openai.com/share/2bede44b-7a03-4201-8eb8-1d1635d11135

Closes #35 